### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The second command retrieves the most recent entry from that stream.
 
 ### Troubleshooting
 - SolverProblemError during poetry install or poetry add
-This is a dependency version conflict. Our project has a specific Python requirement because of the pyautogen library.
+This is a dependency version conflict. Our project has a specific Python requirement because of the ag2 library.
 Solution: Open the pyproject.toml file and ensure your project's Python version is set to python = ">=3.10, <3.14". Your system's base python3 must also fall within this range.
 - ModuleNotFoundError (e.g., No module named 'redis'): This usually means the virtual environment is corrupted or out of sync. A reliable fix is to rebuild it:
 ```

--- a/poetry.lock
+++ b/poetry.lock
@@ -168,7 +168,7 @@ optional = false
 python-versions = ">=3.8"
 
 [[package]]
-name = "pyautogen"
+name = "ag2"
 version = "0.9"
 description = "A programming framework for agentic AI"
 category = "main"
@@ -421,7 +421,7 @@ httpcore = []
 httpx = []
 idna = []
 packaging = []
-pyautogen = []
+ag2 = []
 pydantic = []
 pydantic-core = []
 python-dotenv = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = ["yuki011121 <tyy17723818165@126.com>"]
 python = ">=3.10, <3.14" 
 requests = "^2.32.4"
 redis = "^6.2.0"
-pyautogen = "^0.9"
+ag2 = "^0.9"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
