### PR TITLE
Bug fixes

### DIFF
--- a/shared/a2a_envelope.py
+++ b/shared/a2a_envelope.py
@@ -7,6 +7,7 @@ Wrap payloads in a single, validated structure that every agent publishes to Red
 """
 import uuid
 import json
+import logging
 from datetime import datetime, timezone
 from pydantic import BaseModel, Field, ValidationError
 class SourceAgent(BaseModel):

--- a/shared/redis_bus.py
+++ b/shared/redis_bus.py
@@ -62,7 +62,7 @@ class RedisBus:
             self.client.xgroup_create(stream_name, group_name, id='0', mkstream=True)
             logger.info(f"Created consumer group '{group_name}' on stream '{stream_name}'.")
         except redis.exceptions.ResponseError as e:
-            if b"BUSYGROUP" in e.args[0]:
+            if "BUSYGROUP" in e.args[0]:
                 logger.debug(f"Group '{group_name}' on stream '{stream_name}' already exists.")
             else:
                 raise


### PR DESCRIPTION
When trying to use RedisBus.subscribe() I got two errors.
1) redis_bus.py line 65, in _ensure_group
    if b"BUSYGROUP" in e.args[0]:
TypeError: 'in <string>' requires string as left operand, not bytes

2) "shared/a2a_envelope.py", line 34, in parse_message_from_stream
    logging.error("Message data does not contain 'body' field.")
NameError: name 'logging' is not defined