### PR TITLE
Fixed docker build configuration

### DIFF
--- a/agents/health/Dockerfile
+++ b/agents/health/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.10-slim
+
+# Set working directory
+WORKDIR /workspace
+
+# Install pipx and poetry
+RUN apt-get update && apt-get install -y pipx && pipx install poetry
+ENV PATH="/root/.local/bin:$PATH"
+RUN poetry --version
+
+# Copy project files
+COPY poetry.lock pyproject.toml ./
+COPY .env ./
+COPY agents/health/main.py ./agents/health/
+
+# Set environment variables
+ENV AGENT_NAME=health-agent
+ENV AGENT_VERSION=1.0
+ENV REDIS_URL=redis://redis:6379
+
+CMD ["sleep", "infinity"]

--- a/agents/history/Dockerfile
+++ b/agents/history/Dockerfile
@@ -7,4 +7,5 @@ COPY poetry.lock pyproject.toml ./
 COPY .env ./
 COPY agents/history/main.py  ./agents/history/
 COPY agents/history/models/isrid_tfidf_vectorizer.joblib  ./agents/history/models/
+ENV REDIS_URL=redis://redis:6379
 CMD ["sleep", "infinity"]

--- a/agents/interview/Dockerfile
+++ b/agents/interview/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.10-slim
+
+# Set working directory
+WORKDIR /workspace
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pipx and poetry
+RUN apt-get update && apt-get install -y pipx && pipx install poetry
+ENV PATH="/root/.local/bin:$PATH"
+
+# Copy project files
+COPY poetry.lock pyproject.toml ./
+COPY .env ./
+COPY agents/interview/main.py ./agents/interview/
+
+# Install Python dependencies
+# RUN poetry install --no-dev
+
+# Set environment variables
+ENV AGENT_NAME=interview-agent
+ENV AGENT_VERSION=1.0
+ENV REDIS_URL=redis://redis:6379
+
+CMD ["sleep", "infinity"]

--- a/agents/logistics/Dockerfile
+++ b/agents/logistics/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.10-slim
+
+# Set working directory
+WORKDIR /workspace
+
+# Install pipx and poetry
+RUN apt-get update && apt-get install -y pipx && pipx install poetry
+ENV PATH="/root/.local/bin:$PATH"
+RUN poetry --version
+
+# Copy project files
+COPY poetry.lock pyproject.toml ./
+COPY .env ./
+COPY agents/logistics/main.py ./agents/logistics/
+COPY agents/logistics/communications_agent.py ./agents/logistics/
+COPY agents/logistics/logistics_chief.py ./agents/logistics/
+COPY agents/logistics/resource_supply_agent.py ./agents/logistics/
+COPY agents/logistics/transportation_agent.py ./agents/logistics/
+
+# Set environment variables
+ENV REDIS_URL=redis://redis:6379
+ENV UPDATE_INTERVAL_SECONDS=1800
+
+CMD ["sleep", "infinity"]

--- a/agents/path_analysis/Dockerfile
+++ b/agents/path_analysis/Dockerfile
@@ -1,0 +1,48 @@
+FROM python:3.10-slim
+
+# Set working directory
+WORKDIR /workspace
+
+# Install system dependencies for geospatial libraries and OSM
+# RUN apt-get update && apt-get install -y \
+#     build-essential \
+#     cmake \
+#     gdal-bin \
+#     libgdal-dev \
+#     python3-gdal \
+#     libgeos-dev \
+#     libproj-dev \
+#     libspatialite-dev \
+#     libsqlite3-dev \
+#     libffi-dev \
+#     libssl-dev \
+#     curl \
+#     && rm -rf /var/lib/apt/lists/*
+
+# Install pipx and poetry
+RUN apt-get update && apt-get install -y pipx && pipx install poetry
+ENV PATH="/root/.local/bin:$PATH"
+
+# Copy project files
+COPY poetry.lock pyproject.toml ./
+COPY .env ./
+COPY agents/path_analysis/main.py ./agents/path_analysis/
+COPY agents/path_analysis/dem_utils.py ./agents/path_analysis/
+COPY agents/path_analysis/osm_utils.py ./agents/path_analysis/
+COPY agents/path_analysis/pathing.py ./agents/path_analysis/
+COPY agents/path_analysis/llm.py ./agents/path_analysis/
+
+# Install Python dependencies
+# RUN poetry install --no-dev
+
+# Set environment variables
+ENV AGENT_NAME=path-analysis-agent
+ENV AGENT_VERSION=1.1
+ENV REDIS_URL=redis://redis:6379
+ENV DEM_PATH=agents/path_analysis/data/slo_dem.tif
+ENV START_LON=-120.6605
+ENV START_LAT=35.2980
+ENV TOP_K=3
+ENV DO_VISUALIZE=false
+
+CMD ["sleep", "infinity"]

--- a/agents/photo_analysis/Dockerfile
+++ b/agents/photo_analysis/Dockerfile
@@ -1,0 +1,55 @@
+FROM python:3.10-slim
+
+# Install system dependencies for OpenCV and image processing
+# RUN apt-get update && apt-get install -y \
+#     libglib2.0-0 \
+#     libsm6 \
+#     libxext6 \
+#     libxrender-dev \
+#     libgomp1 \
+#     libglib2.0-0 \
+#     libgthread-2.0-0 \
+#     libgtk-3-0 \
+#     libavcodec-dev \
+#     libavformat-dev \
+#     libswscale-dev \
+#     libv4l-dev \
+#     libxvidcore-dev \
+#     libx264-dev \
+#     libjpeg-dev \
+#     libpng-dev \
+#     libtiff-dev \
+#     libatlas-base-dev \
+#     python3-dev \
+#     python3-numpy \
+#     libtbb2 \
+#     libtbb-dev \
+#     libdc1394-22-dev \
+#     && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Install pipx and poetry
+RUN apt-get update && apt-get install -y pipx && pipx install poetry
+ENV PATH="/root/.local/bin:$PATH"
+
+# Copy project files
+COPY poetry.lock pyproject.toml ./
+COPY .env ./
+COPY agents/photo_analysis/main.py ./agents/photo_analysis/
+
+# Install Python dependencies
+# RUN poetry install --no-dev
+
+# Pre-download YOLO model to avoid download during runtime
+# RUN python -c "from ultralytics import YOLO; YOLO('yolov8m.pt')"
+
+# Create input directory for images
+RUN mkdir -p input_images
+
+# Set environment variables
+ENV IMAGE_INPUT_DIR=/workspace/input_images
+ENV YOLO_MODEL_PATH=yolov8m.pt
+
+CMD ["sleep", "infinity"]
+

--- a/agents/weather/Dockerfile
+++ b/agents/weather/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.10-slim
+
+# Set working directory
+WORKDIR /workspace
+
+# Install pipx and poetry
+RUN apt-get update && apt-get install -y pipx && pipx install poetry
+ENV PATH="/root/.local/bin:$PATH"
+RUN poetry --version
+
+# Copy project files
+COPY poetry.lock pyproject.toml ./
+COPY .env ./
+COPY agents/weather/main.py ./agents/weather/
+
+# Set environment variables
+ENV AGENT_NAME=weather-agent
+ENV AGENT_VERSION=1.1
+ENV REDIS_URL=redis://redis:6379
+ENV LATITUDE=35.2828
+ENV LONGITUDE=-120.6596
+ENV UPDATE_INTERVAL_SECONDS=3600
+
+CMD ["sleep", "infinity"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,8 @@ services:
   # --- SAR Agents ---
   photo-agent:
     build:
-      context: ./agents/photo
+      context: .
+      dockerfile: ./agents/photo_analysis/Dockerfile
     container_name: photo-agent
     env_file: .env
     depends_on: [redis]
@@ -38,7 +39,8 @@ services:
 
   history-agent:
     build:
-      context: ./agents/history
+      context: .
+      dockerfile: ./agents/history/Dockerfile
     container_name: history-agent
     env_file: .env
     depends_on: [redis]
@@ -47,7 +49,8 @@ services:
 
   logistics-agent:
     build:
-      context: ./agents/logistics
+      context: .
+      dockerfile: ./agents/logistics/Dockerfile
     container_name: logistics-agent
     env_file: .env
     depends_on: [redis]
@@ -56,7 +59,8 @@ services:
 
   health-agent:
     build:
-      context: ./agents/health
+      context: .
+      dockerfile: ./agents/health/Dockerfile
     container_name: health-agent
     env_file: .env
     depends_on: [redis]
@@ -65,7 +69,8 @@ services:
 
   path-analysis-agent:
     build:
-      context: ./agents/path-analysis
+      context: .
+      dockerfile: ./agents/path_analysis/Dockerfile
     container_name: path-analysis-agent
     env_file: .env
     depends_on: [redis]
@@ -74,16 +79,18 @@ services:
 
   weather-agent:
     build:
-      context: ./agents/weather
+      context: .
+      dockerfile: ./agents/weather/Dockerfile
     container_name: weather-agent
     env_file: .env
     depends_on: [redis]
     networks:
       - sar-net
-      
+
   interview-agent:
     build:
-      context: ./agents/interview
+      context: .
+      dockerfile: ./agents/interview/Dockerfile
     container_name: interview-agent
     env_file: .env
     depends_on: [redis]


### PR DESCRIPTION
In order for the docker compose configuration to work, we need Dockerfiles for each agent. 

This work needs to be tested with A2A, but is able to be built with `docker compose build --no-cache` and `docker compose up -d`.