### PR TITLE
Fix test system commands

### DIFF
--- a/test_system.sh
+++ b/test_system.sh
@@ -12,9 +12,9 @@ if ! docker info > /dev/null 2>&1; then
 fi
 
 # Check if containers are running
-if ! docker-compose ps | grep -q "Up"; then
+if ! docker compose ps | grep -q "Up"; then
     echo "Starting all SAR agent containers..."
-    docker-compose up -d
+    docker compose up -d
     echo "Waiting for containers to be ready..."
     sleep 15
 fi


### PR DESCRIPTION
docker-compose needs to be changed to "docker compose" for use since docker-compose is not a usable command